### PR TITLE
Use builtin `mkdir` instead of `os.execute()`

### DIFF
--- a/lua/persistent-breakpoints/utils.lua
+++ b/lua/persistent-breakpoints/utils.lua
@@ -2,7 +2,7 @@ local cfg = require('persistent-breakpoints.config')
 local M = {}
 
 M.create_path = function(path)
-	os.execute('mkdir -p ' .. path)
+	vim.fn.mkdir(path, "p")
 end
 
 M.get_bps_path = function ()


### PR DESCRIPTION
Calling the vim builtin should be more portable, give better errors, and should handle paths better