### PR TITLE
feat: expose breakpoints_changed_in_current_buffer so user can manually trigger save of new breakpoints

### DIFF
--- a/lua/persistent-breakpoints/api.lua
+++ b/lua/persistent-breakpoints/api.lua
@@ -3,7 +3,9 @@ local config = require('persistent-breakpoints.config')
 local inmemory_bps = require('persistent-breakpoints.inmemory')
 local breakpoints = require('dap.breakpoints')
 
-local function breakpoints_changed_in_current_buffer()
+local F = {}
+
+F.breakpoints_changed_in_current_buffer = function()
 	local current_buf_file_name = vim.api.nvim_buf_get_name(0)
 	local current_buf_id = vim.api.nvim_get_current_buf()
 	local current_buf_breakpoints = breakpoints.get()[current_buf_id]
@@ -16,16 +18,14 @@ local function breakpoints_changed_in_current_buffer()
 	inmemory_bps.changed = not write_ok
 end
 
-local F = {}
-
 F.toggle_breakpoint = function ()
 	require('dap').toggle_breakpoint();
-	breakpoints_changed_in_current_buffer()
+	F.breakpoints_changed_in_current_buffer()
 end
 
 F.set_conditional_breakpoint = function ()
 	require('dap').set_breakpoint(vim.fn.input('[Condition] > '));
-	breakpoints_changed_in_current_buffer()
+	F.breakpoints_changed_in_current_buffer()
 end
 
 F.clear_all_breakpoints = function ()


### PR DESCRIPTION
In my config I do some special things when creating breakpoints. I think it would be nice to be able to manually call the function to alert of breakpoint changes so we aren't locked down to using the custom commands for toggling breakpoints within the plugin.