### PR TITLE
feat: add configurable callback to be ran when loading breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ require('persistent-breakpoints').setup{
 	load_breakpoints_event = nil,
 	-- record the performance of different function. run :lua require('persistent-breakpoints.api').print_perf_data() to see the result.
 	perf_record = false,
+	-- perform callback when loading a persisted breakpoint
+	--- @param opts DAPBreakpointOptions options used to create the breakpoint ({line, condition, logMessage, hitCondition})
+	--- @param buf_id integer the buffer the breakpoint was set on
+	--- @param line integer the line the breakpoint was set on
+	on_load_breakpoint = nil,
 } 
 ```
 ## Usage

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ require('persistent-breakpoints').setup{
 	-- record the performance of different function. run :lua require('persistent-breakpoints.api').print_perf_data() to see the result.
 	perf_record = false,
 	-- perform callback when loading a persisted breakpoint
-	--- @param opts DAPBreakpointOptions options used to create the breakpoint ({line, condition, logMessage, hitCondition})
+	--- @param opts DAPBreakpointOptions options used to create the breakpoint ({condition, logMessage, hitCondition})
 	--- @param buf_id integer the buffer the breakpoint was set on
 	--- @param line integer the line the breakpoint was set on
 	on_load_breakpoint = nil,

--- a/lua/persistent-breakpoints/api.lua
+++ b/lua/persistent-breakpoints/api.lua
@@ -75,6 +75,9 @@ F.load_breakpoints = function()
 				hit_condition = bp.hitCondition
 			}
 			breakpoints.set(opts, buf_id, line)
+			if config.on_load_breakpoint ~= nil then
+				config.on_load_breakpoint(opts, buf_id, line)
+			end
 		end
 	end
 end

--- a/lua/persistent-breakpoints/config.lua
+++ b/lua/persistent-breakpoints/config.lua
@@ -4,6 +4,7 @@ config = {
 	save_dir = vim.fn.stdpath('data') .. '/nvim_checkpoints',
 	load_breakpoints_event = nil,
 	perf_record = false,
+	on_load_breakpoint = nil,
 }
 
 return config


### PR DESCRIPTION
When I set breakpoints I run certain functions automatically. Having an option like this would help make sure it is ran when I reopen a buffer that had saved breakpoints.