### PR TITLE
docs: add lazy.nvim + modernize keymaps Lua binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ require('persistent-breakpoints').setup{
 ```
 ## Usage
 ```lua
+local persistent_breakpoints = require('persistent-breakpoints.api')
 local opts = { noremap = true, silent = true }
 local keymap = vim.api.nvim_set_keymap
 -- Save breakpoints to file automatically.
-keymap("n", "<YourKey1>", require('persistent-breakpoints.api').toggle_breakpoint, opts)
-keymap("n", "<YourKey2>", require('persistent-breakpoints.api').set_conditional_breakpoint, opts)
-keymap("n", "<YourKey3>", require('persistent-breakpoints.api').clear_all_breakpoints, opts)
+keymap("n", "<YourKey1>", persistent_breakpoints.toggle_breakpoint, opts)
+keymap("n", "<YourKey2>", persistent_breakpoints.set_conditional_breakpoint, opts)
+keymap("n", "<YourKey3>", persistent_breakpoints.clear_all_breakpoints, opts)
 ```
 
 ### **:PBToggleBreakpoint** 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ persistent-breakpoints is a lua plugin for Neovim to save the [nvim-dap](https:/
 ### with `packer.nvim`  
 `use {'Weissle/persistent-breakpoints.nvim'}`  
 ### or with `vim-plug`  
-`Plug 'Weissle/persistent-breakpoints.nvim'`
+`Plug 'Weissle/persistent-breakpoints.nvim'`  
+### or with `lazy.nvim`
+```lua
+{
+	"Weissle/persistent-breakpoints.nvim",
+	event = "BufReadPost",
+	opts = { load_breakpoints_event = { "BufReadPost" } }, -- You can ommit the call to `setup` if you use `opts`
+}
+```
 
 ## Setup
 ```lua
@@ -37,9 +45,9 @@ require('persistent-breakpoints').setup{
 local opts = { noremap = true, silent = true }
 local keymap = vim.api.nvim_set_keymap
 -- Save breakpoints to file automatically.
-keymap("n", "<YourKey1>", "<cmd>lua require('persistent-breakpoints.api').toggle_breakpoint()<cr>", opts)
-keymap("n", "<YourKey2>", "<cmd>lua require('persistent-breakpoints.api').set_conditional_breakpoint()<cr>", opts)
-keymap("n", "<YourKey3>", "<cmd>lua require('persistent-breakpoints.api').clear_all_breakpoints()<cr>", opts)
+keymap("n", "<YourKey1>", require('persistent-breakpoints.api').toggle_breakpoint, opts)
+keymap("n", "<YourKey2>", require('persistent-breakpoints.api').set_conditional_breakpoint, opts)
+keymap("n", "<YourKey3>", require('persistent-breakpoints.api').clear_all_breakpoints, opts)
 ```
 
 ### **:PBToggleBreakpoint** 


### PR DESCRIPTION
I thought it would be nice to add the lazy.nvim setup so that we could close #19 
Also, I modified the way the Lua functions are called to be more inline with current Neovim capabilities.